### PR TITLE
Add a build task

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To test the generated extension, run `grunt run`. A new browser with the test ex
 
 ## Build your extension
 
-To build the generated extension, run `cfx xpi --pkgdir=app`. This command will create an `xpi` file which you can distribute or upload to Mozilla's official Add-ons repository (AMO).
+To build the generated extension, run `cfx xpi --pkgdir=app`. This command will create an `xpi` file which you can distribute or upload to Mozilla's official Add-ons repository (AMO). Alternatively, you can run `grunt build` which will create the `xpi` file in the `dist` folder.
 
 More info on submitting your extension to AMO can be found here: [Submitting an add-on to AMO](https://developer.mozilla.org/en-US/Add-ons/Submitting_an_add-on_to_AMO).
  
@@ -96,6 +96,14 @@ This task finds your Bower components and injects them directly into the HTML fi
 
 ```
 grunt wiredep
+```
+
+### Build
+
+This task build the `xpi` file and puts it in the `dist` folder.
+
+```
+grunt build
 ```
 
 ## Options

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -27,6 +27,12 @@ module.exports = function(grunt) {
                     'mv <%%= config.name %>.xpi <%%= config.dist %>',
                     'wget --post-file=<%%= config.dist %>/<%%= config.name %>.xpi http://localhost:8888/ || echo>/dev/null'
                 ].join('&&')
+            },
+            build: {
+                command: [
+                    'cfx xpi --pkgdir=<%%= config.app %>',
+                    'mv <%%= config.name %>.xpi <%%= config.dist %>'
+                ].join('&&')
             }
         },
         watch: {
@@ -53,5 +59,6 @@ module.exports = function(grunt) {
     });
 
     grunt.registerTask('run', ['shell:run']);
+    grunt.registerTask('build', ['shell:build']);
     grunt.registerTask('default', ['run']);
 };


### PR DESCRIPTION
This adds a `build` task to the Gruntfile which removes the need to call `cfx` explicitly and makes the build process a little more canonical, IMO.
